### PR TITLE
Update Message class with XML documentation and increase text length …

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -3,13 +3,25 @@ using System.ComponentModel.DataAnnotations;
 namespace RazorPagesTestSample.Data
 {
     #region snippet1
+    /// <summary>
+    /// Represents a message with an ID and text content.
+    /// </summary>
     public class Message
     {
+        /// <summary>
+        /// Gets or sets the unique identifier for the message.
+        /// </summary>
         public int Id { get; set; }
 
+        /// <summary>
+        /// Gets or sets the text content of the message.
+        /// </summary>
+        /// <remarks>
+        /// The text content is required and has a maximum length of 250 characters.
+        /// </remarks>
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion


### PR DESCRIPTION
…limit to 250 characters. Resolves Issue 8
This pull request includes documentation improvements and a minor change to the `Message` class in the `RazorPagesTestSample` project. The most important changes include adding XML documentation comments and updating the maximum length for the `Text` property.

Documentation improvements:

* [`src/Application/src/RazorPagesTestSample/Data/Message.cs`](diffhunk://#diff-3ce635672d23bd9cdaa8656d8d117fc07bbea38b87de905339a765df73f3c450R6-R24): Added XML documentation comments for the `Message` class and its properties to provide better context and understanding.

Minor change:

* [`src/Application/src/RazorPagesTestSample/Data/Message.cs`](diffhunk://#diff-3ce635672d23bd9cdaa8656d8d117fc07bbea38b87de905339a765df73f3c450R6-R24): Updated the `StringLength` attribute for the `Text` property from 200 to 250 characters to allow longer messages.